### PR TITLE
query for panels based on panel set id

### DIFF
--- a/src/database/services/PanelService.ts
+++ b/src/database/services/PanelService.ts
@@ -19,6 +19,12 @@ interface PanelInfoGet {
     panel_set_id: number
 }
 
+interface MultiplePanelInfo {
+    id: number,
+    image: string,
+    index: number
+}
+
 /**
  * Perform queries on the 'Panels' table
  */
@@ -54,6 +60,23 @@ class PanelService {
             index: panel.index,
             panel_set_id: panel.panel_set_id
         } as PanelInfoGet
+    }
+
+    /**
+     * Get all panels that are associated with a specific panelSet
+     * @param {number} panel_set_id ID of panelSet
+     * @returns {object[]} An array of objects with id, image, index properties
+     */
+    static async getPanelsFromPanelSetID(panel_set_id: number){
+        // Find all panels on requested panelSet 
+        const panels = await Panel?.findAll({where: {panel_set_id: panel_set_id}});
+        if(!(panels?.length>0)) return undefined
+        
+        //Map panels to keep only needed data
+        const parsedPanels = panels.map((p)=>{return{id: p.id, image: p.image, index: p.index}});
+       
+        //Return the array of panels
+        return parsedPanels as MultiplePanelInfo[];
     }
 }
 

--- a/src/database/services/PanelService.ts
+++ b/src/database/services/PanelService.ts
@@ -69,7 +69,7 @@ class PanelService {
      */
     static async getPanelsFromPanelSetID(panel_set_id: number){
         // Find all panels on requested panelSet 
-        const panels = await Panel?.findAll({where: {panel_set_id: panel_set_id}});
+        const panels = await Panel.findAll({where: {panel_set_id}});
         if(!(panels?.length>0)) return undefined
         
         //Map panels to keep only needed data

--- a/src/database/services/PanelService.ts
+++ b/src/database/services/PanelService.ts
@@ -19,7 +19,7 @@ interface PanelInfoGet {
     panel_set_id: number
 }
 
-interface MultiplePanelInfo {
+interface MultiplePanelInfoGet {
     id: number,
     image: string,
     index: number
@@ -52,7 +52,10 @@ class PanelService {
     static async getPanel(id: number) {
         
         // make sure the panel actually exists
-        const panel = await Panel.findOne({where: { id }, attributes: ['image', 'index', 'panel_set_id']});
+        const panel = await Panel.findOne({
+            where: { id }, 
+            attributes: ['image', 'index', 'panel_set_id']});
+        
         if (!panel) return undefined;
 
         return {
@@ -80,7 +83,7 @@ class PanelService {
           }))
        
         //Return the array of panels
-        return parsedPanels as MultiplePanelInfo[];
+        return parsedPanels as MultiplePanelInfoGet[];
     }
 }
 

--- a/src/database/services/PanelService.ts
+++ b/src/database/services/PanelService.ts
@@ -6,25 +6,6 @@ interface PanelConfig {
     panel_set_id: number,
 }
 
-interface PanelInfoCreate {
-    id: number,
-    image: string,
-    index: number,
-    panel_set_id: number
-}
-
-interface PanelInfoGet {
-    image: string,
-    index: number,
-    panel_set_id: number
-}
-
-interface MultiplePanelInfoGet {
-    id: number,
-    image: string,
-    index: number
-}
-
 /**
  * Perform queries on the 'Panels' table
  */
@@ -41,7 +22,12 @@ class PanelService {
             index: newPanel.index,
             panel_set_id: newPanel.panel_set_id,
         });
-        return {id, image, index, panel_set_id } as PanelInfoCreate;
+        return {id, image, index, panel_set_id } as {
+            id: number,
+            image: string,
+            index: number,
+            panel_set_id: number
+        };
     }
 
     /**
@@ -61,8 +47,8 @@ class PanelService {
         return {
             image: panel.image,
             index: panel.index,
-            panel_set_id: panel.panel_set_id
-        } as PanelInfoGet
+            panel_set_id: panel.panel_set_id as number
+        }
     }
 
     /**
@@ -77,13 +63,13 @@ class PanelService {
         
         //Map panels to keep only needed data
         const parsedPanels = panels.map((p) => ({
-            id: p.id, 
+            id: p.id as number, 
             image: p.image, 
             index: p.index
           }))
        
         //Return the array of panels
-        return parsedPanels as MultiplePanelInfoGet[];
+        return parsedPanels;
     }
 }
 

--- a/src/database/services/PanelService.ts
+++ b/src/database/services/PanelService.ts
@@ -36,7 +36,7 @@ class PanelService {
      * @returns {} PanelInfoCreate
      */
     static async createPanel(newPanel: PanelConfig){
-        const {id, image, index, panel_set_id } = await Panel?.create({
+        const {id, image, index, panel_set_id } = await Panel.create({
             image: newPanel.image,
             index: newPanel.index,
             panel_set_id: newPanel.panel_set_id,
@@ -52,7 +52,7 @@ class PanelService {
     static async getPanel(id: number) {
         
         // make sure the panel actually exists
-        const panel = await Panel?.findOne({where: { id }, attributes: ['image', 'index', 'panel_set_id']});
+        const panel = await Panel.findOne({where: { id }, attributes: ['image', 'index', 'panel_set_id']});
         if (!panel) return undefined;
 
         return {
@@ -70,10 +70,14 @@ class PanelService {
     static async getPanelsFromPanelSetID(panel_set_id: number){
         // Find all panels on requested panelSet 
         const panels = await Panel.findAll({where: {panel_set_id}});
-        if(!(panels?.length>0)) return undefined
+        if(!(panels?.length>0)) return [];
         
         //Map panels to keep only needed data
-        const parsedPanels = panels.map((p)=>{return{id: p.id, image: p.image, index: p.index}});
+        const parsedPanels = panels.map((p) => ({
+            id: p.id, 
+            image: p.image, 
+            index: p.index
+          }))
        
         //Return the array of panels
         return parsedPanels as MultiplePanelInfo[];


### PR DESCRIPTION
### Description
Added a query for `getPanelsFromPanelSetID` that returns an array of panels `{id, image, index}` based on a given `panel_set_id`.

Example Output:
![image](https://github.com/RIT-Crowd-Comic/app-data/assets/89936632/9e91abd2-07fd-46f0-b8b2-5557a3fbb4a7)
